### PR TITLE
Fix extract url failed

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -75,7 +75,7 @@ export default class XHSImporterPlugin extends Plugin {
 
 	// Extract Xiaohongshu URL from share text
 	extractURL(shareText: string): string | null {
-		const urlMatch = shareText.match(/http:\/\/xhslink\.com\/a\/[^\s,，]+/);
+		const urlMatch = shareText.match(/http:\/\/xhslink\.com\/a?o?\/[^\s,，]+/);
 		return urlMatch ? urlMatch[0] : null;
 	}
 


### PR DESCRIPTION
分享链接中间字符是o，导致解析失败。

case 1：
> ❗️黑糖珍珠糍粑🍡糯叽叽的秋冬小甜品 天气渐... http://xhslink.com/o/5tOT2jNLmC0 
复制后打开【小红书】查看笔记！

case 2：
> ‼️捞汁柠檬虾这样做真的太香啦、做法简单 http://xhslink.com/o/7fp0jbJ0uh 
复制后打开【小红书】查看笔记！

使用a?o?匹配中间字符


The middle character of the share link is "o," causing parsing to fail.

case 1：
> ❗️黑糖珍珠糍粑🍡糯叽叽的秋冬小甜品 天气渐... http://xhslink.com/o/5tOT2jNLmC0 
复制后打开【小红书】查看笔记！

case 2：
> ‼️捞汁柠檬虾这样做真的太香啦、做法简单 http://xhslink.com/o/7fp0jbJ0uh 
复制后打开【小红书】查看笔记！

Use a?o? to match the middle character.